### PR TITLE
Support for empty objects in dataloader

### DIFF
--- a/score/db/dataloader.py
+++ b/score/db/dataloader.py
@@ -98,6 +98,8 @@ def _postprocess(data, objects=None):
         cls = classes[classname]
         for id in data[classname]:
             obj = objects[classname][id]
+            if not data[classname][id]:
+                continue
             for member in data[classname][id]:
                 value = data[classname][id][member]
                 if member in relationships[classname]:


### PR DESCRIPTION
The dataloader was not able to handle "empty" objects (i.e. objects
without any member definitions). This patch fixes that issue.
