### PR TITLE
allow create_relationship_class to create a relationship with inherited classes

### DIFF
--- a/score/db/helpers.py
+++ b/score/db/helpers.py
@@ -138,6 +138,7 @@ def create_relationship_class(cls1, cls2, member, *, classname=None,
     if backref:
         rel = relationship(cls1, secondary=cls.__tablename__)
         setattr(cls2, backref, rel)
+        setattr(cls2, 'remote_side', lambda: cls2.id)
     return cls
 
 

--- a/score/db/helpers.py
+++ b/score/db/helpers.py
@@ -136,9 +136,9 @@ def create_relationship_class(cls1, cls2, member, *, classname=None,
         rel = relationship(cls2, secondary=cls.__tablename__)
     setattr(cls1, member, rel)
     if backref:
-        rel = relationship(cls1, secondary=cls.__tablename__)
+        rel = relationship(cls1, secondary=cls.__tablename__,
+                           remote_side=lambda: cls2.id)
         setattr(cls2, backref, rel)
-        setattr(cls2, 'remote_side', lambda: cls2.id)
     return cls
 
 

--- a/score/db/helpers.py
+++ b/score/db/helpers.py
@@ -131,9 +131,11 @@ def create_relationship_class(cls1, cls2, member, *, classname=None,
     cls = type(classname, (cls1.__score_db__['base'],), members)
     if sorted:
         rel = relationship(cls2, secondary=cls.__tablename__,
-                           order_by='%s.index' % cls.__name__)
+                           order_by='%s.index' % cls.__name__,
+                           remote_side=lambda: cls1.id)
     else:
-        rel = relationship(cls2, secondary=cls.__tablename__)
+        rel = relationship(cls2, secondary=cls.__tablename__,
+                           remote_side=lambda: cls1.id)
     setattr(cls1, member, rel)
     if backref:
         rel = relationship(cls1, secondary=cls.__tablename__,


### PR DESCRIPTION
I run into a problem when setting a backref to an inheritance of a class. When we explicit declare the "remote_side" attribute this problem can be fixed in a simple way. another possibility was to check if there is an inheritance between cls1 and cls2 and only set the "remote_side" attribute then.
I don't know if there is any performance difference when setting the attribute explicit for all backref generated with create_relationship_class. If so i can adapt the code to check for inheritance before setting attribute.
