### PR TITLE
Removed relationship cascading declaration

### DIFF
--- a/score/db/helpers.py
+++ b/score/db/helpers.py
@@ -139,23 +139,14 @@ def create_relationship_class(cls1, cls2, member, *, classname=None,
     cls = type(classname, (cls1.__score_db__['base'],), members)
     if sorted:
         rel = relationship(cls2, secondary=cls.__tablename__,
-                           cascade="all, delete-orphan",
-                           passive_deletes=True,
-                           single_parent=True,
                            order_by='%s.index' % cls.__name__,
                            remote_side=lambda: cls1.id)
     else:
         rel = relationship(cls2, secondary=cls.__tablename__,
-                           cascade="all, delete-orphan",
-                           passive_deletes=True,
-                           single_parent=True,
                            remote_side=lambda: cls1.id)
     setattr(cls1, member, rel)
     if backref:
         rel = relationship(cls1, secondary=cls.__tablename__,
-                           cascade="all, delete-orphan",
-                           passive_deletes=True,
-                           single_parent=True,
                            remote_side=lambda: cls2.id)
         setattr(cls2, backref, rel)
     return cls


### PR DESCRIPTION
### Cascading declaration in relationships fails on Many2Many relations

There has been a misunderstanding of Sqlalchemy functionality in the previous pull request. Declaring `cascade`, `passive_deletes` and the necessity of `singe_parent=True` on the relationships in the associated targets refers to the relationship between `cls1` and `cls2`, always. That also is true if we defined cascading on the foreign key relationships in the relational class itself.

```
cascade="all, delete-orphan",
passive_deletes=True,
single_parent=True,
```

Produces Exceptions in the Form of:

```
sqlalchemy.exc.InvalidRequestError: Instance <class *cls2*"> is already associated with an instance of <class *cls1*> via its *cls1.relationship* attribute, and is only allowed a single parent.
```

And vice versa, if we have an explicit `backref`.

Declaring `onupdate="CASCADE"`, and `ondelete="CASCADE"` on the foreign keys themselves seems to be sufficient and behaviour is as expected.
